### PR TITLE
Some miscellaneous suggestions

### DIFF
--- a/jj-describe-mode.el
+++ b/jj-describe-mode.el
@@ -93,6 +93,8 @@
   (setq-local comment-start "JJ: ")
   (setq-local comment-end "")
   (setq-local comment-start-skip "JJ: *")
+  (setq-local font-lock-defaults
+              '((("^JJ:.*$" . font-lock-comment-face))))
   )
 
 ;;;###autoload

--- a/jj-describe-mode.el
+++ b/jj-describe-mode.el
@@ -96,7 +96,7 @@
   )
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\(CHANGE\\|COMMIT\\)-" . jj-describe-mode))
+(add-to-list 'auto-mode-alist '("\\(CHANGE\\|COMMIT\\)-\\|jjdescription" . jj-describe-mode))
 
 (provide 'jj-describe-mode)
 

--- a/jj-describe-mode.el
+++ b/jj-describe-mode.el
@@ -79,11 +79,11 @@
       (while (progn
                (beginning-of-line)
                (looking-at-p comment-start-skip))
-        (delete-line))))
-  (when jj-describe-mode-info-functions
-    (goto-char (point-max))
-    (insert comment-start jj-describe-mode-insert-header "\n")
-    (run-hooks 'jj-describe-mode-info-functions)))
+        (delete-line)))
+    (when jj-describe-mode-info-functions
+      (goto-char (point-max))
+      (insert comment-start jj-describe-mode-insert-header "\n")
+      (run-hooks 'jj-describe-mode-info-functions))))
 
 (defvar jj-describe-mode nil "Is jj-describe-mode active?")
 ;;;###autoload


### PR DESCRIPTION
Happy to break these into separate PRs if you'd prefer, but thought I'd first just check if you even wanted any pull requests against this repo. I appreciate it's probably geared towards personal use, but I found it useful.

I notice that you autoload jj-describe-mode for files named CHANGE- or COMMIT- ... I confess I'm not sure what these are. Whenever I run `jj describe`, I get a file named along the lines of `.jj/repo/editor-UQl3EN.jjdescription`. But maybe I've totally misunderstood how you're using this yourself.

I found that the insert-info method would go to the end of the file, save the cursor position, insert the `jj status` output, then restore the cursor position back to where the end of the file used to be. But presumably it makes more sense to restore the cursor position back to the start of the file where you're about to type a commit message?

I've also added a font-lock face for coloring the JJ comments.